### PR TITLE
Make StereoMemoEnabled show up as enabled by default

### DIFF
--- a/nspector/CustomSettingNames.xml
+++ b/nspector/CustomSettingNames.xml
@@ -4307,6 +4307,7 @@
       <UserfriendlyName>StereoMemoEnabled</UserfriendlyName>
       <HexSettingID>0x707F4B45</HexSettingID>
       <GroupName>7 - Stereo</GroupName>
+      <OverrideDefault>0x00000001</OverrideDefault>
       <SettingValues>
         <CustomSettingValue>
           <UserfriendlyName>Off</UserfriendlyName>


### PR DESCRIPTION
When 3D Vision is enabled, the driver defaults to displaying the stereo
memo, so mark that as the default in CustomSettingNames.xml