### PR TITLE
Fix InputBox DPI issues, allow adding app path by string for UWP ids

### DIFF
--- a/nspector/Common/Helper/InputBox.cs
+++ b/nspector/Common/Helper/InputBox.cs
@@ -61,11 +61,11 @@ namespace nspector.Common.Helper
             buttonOk.Enabled = false;
 
             label.SetBounds(Dpi(9), Dpi(20), Dpi(372), Dpi(13));
-            textBox.SetBounds(Dpi(12), Dpi(36), Dpi(352), Dpi(20));
+            textBox.SetBounds(Dpi(12), Dpi(40), Dpi(352), Dpi(20));
             buttonOk.SetBounds(Dpi(228), Dpi(72), Dpi(75), Dpi(23));
             buttonCancel.SetBounds(Dpi(309), Dpi(72), Dpi(75), Dpi(23));
 
-            imageBox.SetBounds(Dpi(368), Dpi(36), Dpi(16), Dpi(16));
+            imageBox.SetBounds(Dpi(368), Dpi(40), Dpi(16), Dpi(16));
 
             label.AutoSize = true;
             imageBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;

--- a/nspector/Common/Helper/InputBox.cs
+++ b/nspector/Common/Helper/InputBox.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
@@ -9,13 +10,14 @@ namespace nspector.Common.Helper
     internal class InputBox
     {
 
-        internal static DialogResult Show(string title, string promptText, ref string value, List<string> invalidInputs, string mandatoryFormatRegExPattern, int maxLength)
+        internal static DialogResult Show(string title, string promptText, ref string value, List<string> invalidInputs, string mandatoryFormatRegExPattern, int maxLength, bool allowExeBrowse = false)
         {
             var form = new Form();
             var label = new Label();
             var textBox = new TextBox();
             var buttonOk = new Button();
             var buttonCancel = new Button();
+            var buttonBrowse = new Button();
             var imageBox = new PictureBox();
 
             EventHandler textchanged = delegate (object sender, EventArgs e)
@@ -43,9 +45,22 @@ namespace nspector.Common.Helper
                 buttonOk.Enabled = true;
             };
 
+            EventHandler buttonBrowse_Click = delegate (object sender, EventArgs e)
+            {
+                var openDialog = new OpenFileDialog();
+                openDialog.DefaultExt = "*.exe";
+                openDialog.Filter = "Application EXE Name|*.exe|Application Absolute Path|*.exe";
+
+                if (openDialog.ShowDialog() == DialogResult.OK)
+                {
+                    string applicationName = new FileInfo(openDialog.FileName).Name;
+                    if (openDialog.FilterIndex == 2)
+                        applicationName = openDialog.FileName;
+                    textBox.Text = applicationName;
+                }
+            };
 
             textBox.TextChanged += textchanged;
-
 
             form.Text = title;
             label.Text = promptText;
@@ -55,28 +70,47 @@ namespace nspector.Common.Helper
 
             buttonOk.Text = "OK";
             buttonCancel.Text = "Cancel";
+            buttonBrowse.Text = "Browse...";
             buttonOk.DialogResult = DialogResult.OK;
             buttonCancel.DialogResult = DialogResult.Cancel;
 
             buttonOk.Enabled = false;
 
             label.SetBounds(Dpi(9), Dpi(20), Dpi(372), Dpi(13));
-            textBox.SetBounds(Dpi(12), Dpi(40), Dpi(352), Dpi(20));
-            buttonOk.SetBounds(Dpi(228), Dpi(72), Dpi(75), Dpi(23));
-            buttonCancel.SetBounds(Dpi(309), Dpi(72), Dpi(75), Dpi(23));
+            textBox.SetBounds(Dpi(12), Dpi(44), Dpi(352), Dpi(20));
+            buttonOk.SetBounds(Dpi(224), Dpi(72), Dpi(75), Dpi(23));
+            buttonCancel.SetBounds(Dpi(305), Dpi(72), Dpi(75), Dpi(23));
+
+            if (allowExeBrowse)
+            {
+                textBox.SetBounds(Dpi(12), Dpi(44), Dpi(286), Dpi(20));
+                buttonBrowse.SetBounds(Dpi(305), Dpi(39), Dpi(75), Dpi(23));
+                buttonBrowse.Click += buttonBrowse_Click;
+            }
 
             imageBox.SetBounds(Dpi(368), Dpi(40), Dpi(16), Dpi(16));
 
             label.AutoSize = true;
+            label.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             imageBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+            textBox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            buttonBrowse.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
 
             form.ClientSize = new Size(Dpi(396), Dpi(107));
             form.ClientSize = new Size(Math.Max(Dpi(300), label.Right + Dpi(10)), form.ClientSize.Height);
-            form.Controls.AddRange(new Control[] { label, textBox, imageBox, buttonOk, buttonCancel });
-            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.MinimumSize = form.Size;
+            form.MaximumSize = new Size(form.MinimumSize.Width * 2, form.MinimumSize.Height);
+
+            form.Controls.AddRange(new Control[] { label, textBox, buttonOk, buttonCancel });
+            if (!allowExeBrowse)
+                form.Controls.Add(imageBox);
+            else
+                form.Controls.Add(buttonBrowse);
+
+            form.ShowIcon = false;
+            form.FormBorderStyle = FormBorderStyle.Sizable;
             form.StartPosition = FormStartPosition.CenterParent;
             form.MinimizeBox = false;
             form.MaximizeBox = false;

--- a/nspector/Common/Helper/InputBox.cs
+++ b/nspector/Common/Helper/InputBox.cs
@@ -88,7 +88,7 @@ namespace nspector.Common.Helper
                 buttonBrowse.Click += buttonBrowse_Click;
             }
 
-            imageBox.SetBounds(Dpi(368), Dpi(40), Dpi(16), Dpi(16));
+            imageBox.SetBounds(Dpi(368), Dpi(44), Dpi(16), Dpi(16));
 
             label.AutoSize = true;
             label.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;

--- a/nspector/frmDrvSettings.Designer.cs
+++ b/nspector/frmDrvSettings.Designer.cs
@@ -408,6 +408,7 @@
             this.lblApplications.Size = new System.Drawing.Size(840, 17);
             this.lblApplications.TabIndex = 25;
             this.lblApplications.Text = "fsagame.exe, bond.exe, herozero.exe";
+            this.lblApplications.DoubleClick += new System.EventHandler(this.lblApplications_DoubleClick);
             // 
             // toolStripButton5
             // 

--- a/nspector/frmDrvSettings.Designer.cs
+++ b/nspector/frmDrvSettings.Designer.cs
@@ -408,7 +408,7 @@
             this.lblApplications.Size = new System.Drawing.Size(840, 17);
             this.lblApplications.TabIndex = 25;
             this.lblApplications.Text = "fsagame.exe, bond.exe, herozero.exe";
-            this.lblApplications.DoubleClick += new System.EventHandler(this.lblApplications_DoubleClick);
+            this.lblApplications.DoubleClick += new System.EventHandler(this.tsbAddApplication_Click);
             // 
             // toolStripButton5
             // 

--- a/nspector/frmDrvSettings.cs
+++ b/nspector/frmDrvSettings.cs
@@ -537,6 +537,10 @@ namespace nspector
         {
             ScaleFactor = lblWidth330.Width / 330;
 
+            // Later Windows versions changed DPI scaling method, check with Graphics and use it if larger
+            using (Graphics g = CreateGraphics())
+                ScaleFactor = Math.Max(ScaleFactor, Math.Max(g.DpiX / 96f, g.DpiY / 96f));
+
             chSettingID.Width = lblWidth330.Width;
             chSettingValueHex.Width = lblWidth96.Width;
         }

--- a/nspector/frmDrvSettings.cs
+++ b/nspector/frmDrvSettings.cs
@@ -631,6 +631,8 @@ namespace nspector
                 ResetSelectedValue();
         }
 
+        ToolTip appPathsTooltip = new ToolTip() { InitialDelay = 250 };
+
         private void ChangeCurrentProfile(string profileName)
         {
             if (profileName == GetBaseProfileName() || profileName == _baseProfileName)
@@ -649,6 +651,10 @@ namespace nspector
                 tssbRemoveApplication.Enabled = true;
             }
 
+            string appPathsTooltipText = "Double-click to add application path/name/ID";
+            if (profileName == GetBaseProfileName() || profileName == _baseProfileName || profileName.StartsWith("0x"))
+                appPathsTooltipText = "";
+            appPathsTooltip.SetToolTip(lblApplications, appPathsTooltipText);
 
             RefreshCurrentProfile();
         }

--- a/nspector/frmDrvSettings.cs
+++ b/nspector/frmDrvSettings.cs
@@ -816,7 +816,15 @@ namespace nspector
                 }
             }
             else
-                ResetCurrentProfile();
+            {
+                if (MessageBox.Show(this,
+                    "Restore profile to NVIDIA driver defaults?",
+                    "Restore profile",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                {
+                    ResetCurrentProfile();
+                }
+            }
         }
 
         private void tsbRefreshProfile_Click(object sender, EventArgs e)
@@ -927,15 +935,24 @@ namespace nspector
 
         private void tsbAddApplication_Click(object sender, EventArgs e)
         {
-            var openDialog = new OpenFileDialog();
-            openDialog.DefaultExt = "*.exe";
-            openDialog.Filter = "Application EXE Name|*.exe|Application Absolute Path|*.exe";
+            if (_CurrentProfile == GetBaseProfileName() || _CurrentProfile == _baseProfileName)
+                return;
 
-            if (openDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            var applications = new Dictionary<string, string>();
+            _currentProfileSettingItems = _drs.GetSettingsForProfile(_CurrentProfile, GetSettingViewMode(), ref applications);
+
+            var existingPaths = new HashSet<string>(applications.Values, StringComparer.OrdinalIgnoreCase);
+            var applicationName = "";
+
+            if (InputBox.Show("Add Application", "Enter an application path/filename/UWP ID to add to the profile:", ref applicationName, new List<string>(), "", 2048, true) == DialogResult.OK)
             {
-                string applicationName = new FileInfo(openDialog.FileName).Name;
-                if (openDialog.FilterIndex == 2)
-                    applicationName = openDialog.FileName;
+                // Add new application path
+                if (existingPaths.Contains(applicationName))
+                {
+                    MessageBox.Show("This application is already assigned to this profile!",
+                        "Error adding Application", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
 
                 try
                 {
@@ -946,25 +963,26 @@ namespace nspector
                     if (ex.Status == Native.NVAPI2.NvAPI_Status.NVAPI_EXECUTABLE_ALREADY_IN_USE || ex.Status == Native.NVAPI2.NvAPI_Status.NVAPI_ERROR)
                     {
                         if (lblApplications.Text.ToUpper().IndexOf(" " + applicationName.ToUpper() + ",") != -1)
-                            MessageBox.Show("This application executable is already assigned to this profile!",
+                            MessageBox.Show("This application is already assigned to this profile!",
                                 "Error adding Application", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         else
                         {
                             string profileNames = _scanner.FindProfilesUsingApplication(applicationName);
                             if (profileNames == "")
-                                MessageBox.Show("This application executable might already be assigned to another profile!",
+                                MessageBox.Show("This application might already be assigned to another profile!",
                                     "Error adding Application", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             else
                                 MessageBox.Show(
-                                    "This application executable is already assigned to the following profiles: " +
+                                    "This application is already assigned to the following profiles: " +
                                     profileNames, "Error adding Application", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                     else
                         throw;
                 }
+
+                RefreshCurrentProfile();
             }
-            RefreshCurrentProfile();
         }
 
         private void tssbRemoveApplication_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
@@ -1410,38 +1428,6 @@ namespace nspector
             
             Clipboard.SetText(sbSettings.ToString());
 
-        }
-
-        private void lblApplications_DoubleClick(object sender, EventArgs e)
-        {
-            if (_CurrentProfile == GetBaseProfileName() || _CurrentProfile == _baseProfileName)
-                return;
-            if (_CurrentProfile.StartsWith("0x"))
-                return; // monitor/device profile
-
-            var applications = new Dictionary<string, string>();
-            _currentProfileSettingItems = _drs.GetSettingsForProfile(_CurrentProfile, GetSettingViewMode(), ref applications);
-
-            var existingPaths = new HashSet<string>(applications.Values, StringComparer.OrdinalIgnoreCase);
-            var appPath = "";
-
-            if (InputBox.Show("Add App Path", "Enter application path/filename/UWP ID to add to the profile", ref appPath, new List<string>(), "", 2048) == DialogResult.OK)
-            {
-                // Add new application path
-                if (!existingPaths.Contains(appPath))
-                {
-                    try
-                    {
-                        _drs.AddApplication(_CurrentProfile, appPath);
-                    }
-                    catch (NvapiException ex) // NVAPI_EXECUTABLE_ALREADY_IN_USE etc
-                    {
-                        MessageBox.Show(ex.Message, "NvAPI Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
-
-                    RefreshCurrentProfile();
-                }
-            }
         }
     }
 }

--- a/nspector/frmDrvSettings.cs
+++ b/nspector/frmDrvSettings.cs
@@ -1405,6 +1405,38 @@ namespace nspector
             Clipboard.SetText(sbSettings.ToString());
 
         }
+
+        private void lblApplications_DoubleClick(object sender, EventArgs e)
+        {
+            if (_CurrentProfile == GetBaseProfileName() || _CurrentProfile == _baseProfileName)
+                return;
+            if (_CurrentProfile.StartsWith("0x"))
+                return; // monitor/device profile
+
+            var applications = new Dictionary<string, string>();
+            _currentProfileSettingItems = _drs.GetSettingsForProfile(_CurrentProfile, GetSettingViewMode(), ref applications);
+
+            var existingPaths = new HashSet<string>(applications.Values, StringComparer.OrdinalIgnoreCase);
+            var appPath = "";
+
+            if (InputBox.Show("Add App Path", "Enter application path/filename/UWP ID to add to the profile", ref appPath, new List<string>(), "", 2048) == DialogResult.OK)
+            {
+                // Add new application path
+                if (!existingPaths.Contains(appPath))
+                {
+                    try
+                    {
+                        _drs.AddApplication(_CurrentProfile, appPath);
+                    }
+                    catch (NvapiException ex) // NVAPI_EXECUTABLE_ALREADY_IN_USE etc
+                    {
+                        MessageBox.Show(ex.Message, "NvAPI Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+
+                    RefreshCurrentProfile();
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes an issue with inputbox scaling, there's code to handle scaling already but think there was a change to how Windows handled DPI, so ScaleFactor was always set to 1, seems to use the right scale for me now:
![nvidiaProfileInspector_2025-02-16_15-48-38](https://github.com/user-attachments/assets/b95f172a-28a5-4345-8b20-94140ab9fe68)
->
![nvidiaProfileInspector_2025-02-16_15-56-24](https://github.com/user-attachments/assets/b2e87d1a-bed3-4499-ae08-79ea3055bbae)

Also changed "add application" button to show an inputbox with a "browse..." button, so app path could also be entered by text.
There was already a file-picker for EXEs but that wouldn't allow adding UWP game IDs, atm only way is to export & edit .nip files.
(eg. indiana jones profile didn't include UWP id which caused some FG stutters, a fix was posted asking people to save it as .nip and import etc, but now they could just enter the ID into NVPI)

![image](https://github.com/user-attachments/assets/0536a6ae-3c10-4179-b17b-8b321f94d5f4)

Double-clicking the green app bar will also show the same dialog too.

Lastly added a yes/no confirmation to the restore defaults button since it was easy to misclick.