### PR TITLE
CSN File Update: Add Dynamic FG, Shader Pre-compile

### DIFF
--- a/nvidiaProfileInspector/CustomSettingNames.xml
+++ b/nvidiaProfileInspector/CustomSettingNames.xml
@@ -1037,6 +1037,7 @@
 			<UserfriendlyName>DLSS-FG - Forced Mode</UserfriendlyName>
 			<HexSettingID>0x10308298</HexSettingID>
 			<GroupName>5 - Common</GroupName>
+			<Description>This sets up the mode for Frame Generation, Fixed mode uses the "Fixed Frame Generation Count" and Dynamic uses "Dynamic Frame Generation Count".</Description>
 			<MinRequiredDriverVersion>0</MinRequiredDriverVersion>
 			<SettingValues>
 				<CustomSettingValue>


### PR DESCRIPTION
- Add HexValue 0x000802A5 to OGL_DX_PRESENT_DEBUG. 
This is a hidden hexvalue to make the driver treat DXK as Native, a workaround for when the flag to promote to DXGI/DirectFlip doesn't work.

- Remove the Override Defaults for reBAR - Size Limit, as it can cause confusion with the default values for some whitelisted games.