### PR TITLE
Allow searching settings by hex ID in filter

### DIFF
--- a/nvidiaProfileInspector/UI/ViewModels/MainViewModel.cs
+++ b/nvidiaProfileInspector/UI/ViewModels/MainViewModel.cs
@@ -675,6 +675,8 @@ namespace nvidiaProfileInspector.UI.ViewModels
                 if (!string.IsNullOrEmpty(altNamesToCheck) &&
                     altNamesToCheck.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0)
                     return true;
+                if (item.SettingIdHex.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
             }
             return false;
         }

--- a/nvidiaProfileInspector/UI/ViewModels/SettingsListViewModel.cs
+++ b/nvidiaProfileInspector/UI/ViewModels/SettingsListViewModel.cs
@@ -66,6 +66,8 @@ namespace nvidiaProfileInspector.UI.ViewModels
                 var matches = item.DisplayName.IndexOf(_filterText, System.StringComparison.OrdinalIgnoreCase) >= 0;
                 if (!matches && !string.IsNullOrEmpty(item.AlternateNames))
                     matches = item.AlternateNames.IndexOf(_filterText, System.StringComparison.OrdinalIgnoreCase) >= 0;
+                if (!matches)
+                    matches = item.SettingIdHex.IndexOf(_filterText, System.StringComparison.OrdinalIgnoreCase) >= 0;
                 e.Accepted = matches;
             }
         }


### PR DESCRIPTION
The search filter currently only matches against `DisplayName` and `AlternateNames`. This change adds a check against `SettingIdHex` to allow finding items by their hex ID (e.g. 0x00DE5C4E).