### PR TITLE
Fixed navigating to the global driver profile when Base Profile is selected

### DIFF
--- a/nvidiaProfileInspector/UI/ViewModels/MainViewModel.cs
+++ b/nvidiaProfileInspector/UI/ViewModels/MainViewModel.cs
@@ -1329,6 +1329,9 @@ namespace nvidiaProfileInspector.UI.ViewModels
 
         public void SelectProfile(string profileName)
         {
+            if (string.Equals(profileName, _baseProfileName, StringComparison.OrdinalIgnoreCase))
+                profileName = DrsSettingsService.GlobalProfileName;
+
             if (_profileNames.Any(x => x.ProfileName == profileName))
                 SetCurrentProfile(profileName, forceNotify: true);
         }


### PR DESCRIPTION
Fixed modified profiles dropdown not navigating to the `GLOBAL DRIVER PROFILE` when `Base Profile` is selected, by assigning its internal name to the display name used in the profile list.