### PR TITLE
Update profile enum buffer sizing to match the number of settings, improving scan performance

### DIFF
--- a/nvidiaProfileInspector/Common/DrsScannerService.cs
+++ b/nvidiaProfileInspector/Common/DrsScannerService.cs
@@ -133,7 +133,7 @@ namespace nvidiaProfileInspector.Common
                         if ((foundModifiedProfile && justModified) || checkedSettingsCount >= profile.numOfSettings)
                             continue;
 
-                        var settings = GetProfileSettings(hSession, hProfile);
+                        var settings = GetProfileSettings(hSession, hProfile, profile.numOfSettings);
                         foreach (var setting in settings)
                         {
                             if (knownPredefines.IndexOf(setting.settingId) < 0)

--- a/nvidiaProfileInspector/Common/DrsSettingsServiceBase.cs
+++ b/nvidiaProfileInspector/Common/DrsSettingsServiceBase.cs
@@ -292,9 +292,9 @@ namespace nvidiaProfileInspector.Common
             return profileHandles;
         }
 
-        protected List<NVDRS_SETTING> GetProfileSettings(IntPtr hSession, IntPtr hProfile)
+        protected List<NVDRS_SETTING> GetProfileSettings(IntPtr hSession, IntPtr hProfile, uint expectedCount = 512)
         {
-            uint settingCount = 512;
+            uint settingCount = expectedCount > 0 ? expectedCount : 1;
             var settings = new NVDRS_SETTING[settingCount];
             settings[0].version = NvapiDrsWrapper.NVDRS_SETTING_VER;
 


### PR DESCRIPTION
- Profile scanning currently reads every profile through a fixed 512-slot buffer, even though most profiles only have a handful of settings. Each slot is ~12 KB, so every profile incurs a cost of moving ~6 MB to and from the driver no matter how much data it actually holds
- Now sizes the buffer to each profile's actual setting count (retrieved through the `numOfSettings` property exposed from the driver), so it only moves what's needed
- During testing, initial scanning was noticeably faster; saw ~19% reduction in scan time.