### PR TITLE
NVIDIA Ansel - Update CustomSettingNames.xml

### DIFF
--- a/nvidiaProfileInspector/CustomSettingNames.xml
+++ b/nvidiaProfileInspector/CustomSettingNames.xml
@@ -1846,9 +1846,9 @@ When any driver flags are set HDR will be applied via driver instead of through 
       <Hidden>true</Hidden>
     </CustomSetting>-->
 		<CustomSetting>
-			<UserfriendlyName>NVIDIA App Overlay - Enabled</UserfriendlyName>
+			<UserfriendlyName>NVIDIA Ansel - Enabled</UserfriendlyName>
 			<HexSettingID>0x1075D972</HexSettingID>
-			<Description>Enables or disables NVIDIA App Overlay (formerly Ansel / GeForce Experience overlay) support for the profile.</Description>
+			<Description>Enables or disables NVIDIA Ansel support for the profile.</Description>
 			<GroupName>06 - Rendering Features</GroupName>
 			<SettingValues>
 				<CustomSettingValue>

--- a/nvidiaProfileInspector/CustomSettingNames.xml
+++ b/nvidiaProfileInspector/CustomSettingNames.xml
@@ -1848,7 +1848,7 @@ When any driver flags are set HDR will be applied via driver instead of through 
 		<CustomSetting>
 			<UserfriendlyName>NVIDIA Ansel - Enabled</UserfriendlyName>
 			<HexSettingID>0x1075D972</HexSettingID>
-			<Description>Enables or disables NVIDIA Ansel support for the profile.</Description>
+			<Description>Enables or disables NVIDIA Ansel support for the profile. Ansel is a photo mode for supported games developed by NVIDIA, allowing the use of a free camera to take photos of a game. The mode is also able to increase the graphical fidelity of a game so players do not have to change settings manually as they engage or disengage the photo mode.</Description>
 			<GroupName>06 - Rendering Features</GroupName>
 			<SettingValues>
 				<CustomSettingValue>

--- a/nvidiaProfileInspector/Reference.xml
+++ b/nvidiaProfileInspector/Reference.xml
@@ -18726,23 +18726,23 @@
 			<SettingValues>
 				<CustomSettingValue>
 					<UserfriendlyName>Off</UserfriendlyName>
-					<HexValue>0x00000000</HexValue>
+					<HexValue>0x00000004</HexValue>
 				</CustomSettingValue>
 				<CustomSettingValue>
 					<UserfriendlyName>Low [Default]</UserfriendlyName>
-					<HexValue>0x00000001</HexValue>
+					<HexValue>0x00000000</HexValue>
 				</CustomSettingValue>
 				<CustomSettingValue>
 					<UserfriendlyName>Medium</UserfriendlyName>
-					<HexValue>0x00000002</HexValue>
+					<HexValue>0x00000001</HexValue>
 				</CustomSettingValue>
 				<CustomSettingValue>
 					<UserfriendlyName>High</UserfriendlyName>
-					<HexValue>0x00000003</HexValue>
+					<HexValue>0x00000002</HexValue>
 				</CustomSettingValue>
 				<CustomSettingValue>
 					<UserfriendlyName>Ultra</UserfriendlyName>
-					<HexValue>0x00000004</HexValue>
+					<HexValue>0x00000003</HexValue>
 				</CustomSettingValue>
 			</SettingValues>
 		</CustomSetting>


### PR DESCRIPTION
NVIDIA Ansel (Alt +F2 in-game shortcut) works without NVIDIA App and it's still implemented in modern games https://steamdb.info/tech/SDK/NVIDIA_Ansel/?sort=release_desc

This flag toggles only the Ansel feature and not the NVIDIA App Overlay.

Ansel can also be tweaked with NVCameraTool
https://international-gfe.download.nvidia.com/GFE/GFEClient/NVCameraConfiguration/v1.0/NVCameraConfiguration_v1.0.0.6.zip